### PR TITLE
Create module for DC motor control and DC motor CLI

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,7 @@
 
 # Change this to compile for a different environment
 [platformio]
-default_envs = bluepill_f103c8, uno
+default_envs = bluepill_f103c8
 
 # Common environment data (injectable into each env)
 [common_env_data]

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@ default_envs = bluepill_f103c8
 # Common environment data (injectable into each env)
 [common_env_data]
     upload_protocol = serial
-    upload_port = /dev/ttyUSB1
+    upload_port = /dev/ttyUSB0
     lib_deps = 
         gitlab-airbornemint/Protothreads@^1.4.0-arduino.beta.1
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,16 +55,15 @@ void setup()
     flag = true;
 
     // Initialize peripherals
+    if (taskCli_init() != ROBOT_OK)
+    {
+
+    }
     if (taskDriving_init() != ROBOT_OK)
     {
         // TODO: Figure out some sort of error handler
-        return;
-    } 
-    else if (taskCli_init() != ROBOT_OK)
-    {
-        return;
     }
-
+    
     // Get task references
     task_driving = taskDriving_getTask();
     task_cli = taskCli_getTask();

--- a/src/robot-cli/cli-dc-motor.cpp
+++ b/src/robot-cli/cli-dc-motor.cpp
@@ -8,11 +8,16 @@
 *******************************************************************************/
 
 #include "cli-dc-motor.h"
+#include "robot-core/dc-motor.h"
 #include "robot-core/command.h"
+#include "utilities/util-vars.h"
 
 /*******************************************************************************
 *                               Static Functions
 *******************************************************************************/
+
+static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
+                              dc_motor_dir_t dir);
 
 /*******************************************************************************
 *                               Constants
@@ -32,6 +37,68 @@
 
 cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
 {
-    Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
+    dc_motor_t motor = (dc_motor_t) strtol((const char*) args[0], NULL, 0);
+
+    if (motor < DC_MOTOR_1 || motor > DC_MOTOR_2)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " motor\"}" CMD_EOL_STR));
+    }
+    else if (dcMotor_init(motor) != ROBOT_OK)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor init"
+                     " failed\"}" CMD_EOL_STR));
+    }
+    else
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
+    }
     return COMMAND_OK;
+}
+
+cli_status_t cliDcMotor_run(uint8_t argNumber, char* args[])
+{
+    dc_motor_t motor = (dc_motor_t) strtol((const char*) args[0], 
+                                           NULL, 0);
+    uint8_t speed = (uint8_t) strtol((const char*) args[1], 
+                                     NULL, 0);
+
+    if (motor < DC_MOTOR_1 || motor > DC_MOTOR_2)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " motor\"}" CMD_EOL_STR));
+        return COMMAND_OK;
+    }
+    if (speed < STATIC_SPEED || speed > MAX_SPEED)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": invalid"
+                     " speed\"}" CMD_EOL_STR));
+        return COMMAND_OK;
+    }
+
+    if (strcmp(args[2], "left") == 0)
+    {
+        _runMotorFeedback(motor, speed, CC_DIRECTION);
+    }
+    else if (strcmp(args[2], "right") == 0)
+    {
+        _runMotorFeedback(motor, speed, CW_DIRECTION);
+    }
+    else
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " direction\"}" CMD_EOL_STR));
+    }
+    return COMMAND_OK;
+}
+
+static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
+                                        dc_motor_dir_t dir)
+{
+    if (dcMotor_run(motor, speed, dir) != ROBOT_OK)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor run"
+                     " failed\"}" CMD_EOL_STR));
+    }
+    Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
 }

--- a/src/robot-cli/cli-dc-motor.h
+++ b/src/robot-cli/cli-dc-motor.h
@@ -33,7 +33,9 @@
 
 cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[]);
 
-#define DC_MOTOR_COMMANDS                                                      \
-    {cliDcMotor_init, "dc-init", "<periph>", "init the dc-motor periph", 1, 1},
+cli_status_t cliDcMotor_run(uint8_t argNumber, char* args[]);
 
+#define DC_MOTOR_COMMANDS                                                                     \
+    {cliDcMotor_init, "dc-init", "<periph>",               "init the dc-motor periph", 1, 1}, \
+    {cliDcMotor_run,  "dc-run",  "<periph> <speed> <dir>", "run the dc motor",         3, 3},
 #endif // CLI_DC_MOTOR

--- a/src/robot-core/dc-motor.cpp
+++ b/src/robot-core/dc-motor.cpp
@@ -15,9 +15,42 @@
 *                               Static Functions
 *******************************************************************************/
 
+static void _runDir(uint8_t pin1, uint8_t pin2, dc_motor_dir_t dir, 
+                    uint8_t speed);
+static void _initMotor(uint8_t pin1, uint8_t pin2, uint8_t power);
+
 /*******************************************************************************
 *                               Constants
 *******************************************************************************/
+
+#ifdef UNO
+#define PIN_1_MOTOR_1  9
+#define PIN_2_MOTOR_1  10
+#define PIN_1_MOTOR_2  3
+#define PIN_2_MOTOR_2  5
+#define POWER_MOTOR_1  7
+#define POWER_MOTOR_2  8
+#elif STM32
+#define PIN_1_MOTOR_1  PB8
+#define PIN_2_MOTOR_1  PB9
+#define PIN_1_MOTOR_2  PB6
+#define PIN_2_MOTOR_2  PB7
+#define POWER_MOTOR_1  PA15
+#define POWER_MOTOR_2  PA12
+#else
+#define PIN_1_MOTOR_1  PB8
+#define PIN_2_MOTOR_1  PB9
+#define PIN_1_MOTOR_2  PB6
+#define PIN_2_MOTOR_2  PB7
+#define POWER_MOTOR_1  PA15
+#define POWER_MOTOR_2  PA12
+#endif
+
+#define SLOW_SPEED     100
+#define MEDIUM_SPEED   150
+#define FAST_SPEED     250
+
+#define FADE_DELAY     3
 
 /*******************************************************************************
 *                               Structures
@@ -31,7 +64,87 @@
 *                               Functions
 *******************************************************************************/
 
-robot_status_t dcMotor_init()
+robot_status_t dcMotor_init(dc_motor_t motor)
 {
+
+    if (motor == DC_MOTOR_1)
+    {
+        _initMotor(PIN_1_MOTOR_1, PIN_2_MOTOR_1, POWER_MOTOR_1);
+    }
+    else
+    {
+        _initMotor(PIN_1_MOTOR_2, PIN_2_MOTOR_2, POWER_MOTOR_2);
+    }
+
     return ROBOT_OK;
+}
+
+robot_status_t dcMotor_run(dc_motor_t motor, uint8_t speed, dc_motor_dir_t dir)
+{
+    if (motor == DC_MOTOR_1)
+    {
+        _runDir(PIN_1_MOTOR_1, PIN_2_MOTOR_1, dir, speed);
+    }
+    else
+    {
+        _runDir(PIN_1_MOTOR_2, PIN_2_MOTOR_2, dir, speed);
+    }
+
+    return ROBOT_OK;
+}
+
+static void _runDir(uint8_t pin1, uint8_t pin2, dc_motor_dir_t dir, 
+                    uint8_t speed)
+{
+    if (dir == CC_DIRECTION)
+    {
+        analogWrite(pin1, speed);
+        analogWrite(pin2, STATIC_SPEED);
+    }
+    else
+    {
+        analogWrite(pin1, STATIC_SPEED);
+        analogWrite(pin2, speed);
+    }
+}
+
+static void _initMotor(uint8_t pin1, uint8_t pin2, uint8_t power)
+{
+    // Initialize the dc motor pins
+    pinMode(pin1, OUTPUT);
+    pinMode(pin2, OUTPUT);
+    pinMode(power, OUTPUT);
+
+    // Make sure all the motors driving pins are set LOW
+    digitalWrite(pin1, LOW);
+    digitalWrite(pin2, LOW);
+
+    // Power the motor driver
+    digitalWrite(power, HIGH);
+
+    for (uint8_t i = STATIC_SPEED; i < MAX_SPEED; i++)
+    {
+        analogWrite(pin1, i);
+        delay(FADE_DELAY);
+    }
+    for (uint8_t i = MAX_SPEED - 1; i > STATIC_SPEED; i--)
+    {
+        analogWrite(pin1, i);
+        delay(FADE_DELAY);
+    }
+
+    analogWrite(pin1, STATIC_SPEED);
+
+    for (uint8_t i = STATIC_SPEED; i < MAX_SPEED; i++)
+    {
+        analogWrite(pin2, i);
+        delay(FADE_DELAY);
+    }
+    for (uint8_t i = MAX_SPEED - 1; i > STATIC_SPEED; i--)
+    {
+        analogWrite(pin2, i);
+        delay(FADE_DELAY);
+    }
+
+    analogWrite(pin2, STATIC_SPEED);
 }

--- a/src/robot-core/dc-motor.h
+++ b/src/robot-core/dc-motor.h
@@ -22,9 +22,22 @@
 *                               Constants
 *******************************************************************************/
 
+#define MAX_SPEED    255
+#define STATIC_SPEED 0
+
 /*******************************************************************************
 *                               Structures
 *******************************************************************************/
+
+typedef enum {
+    CW_DIRECTION,
+    CC_DIRECTION
+} dc_motor_dir_t;
+
+typedef enum {
+    DC_MOTOR_1,
+    DC_MOTOR_2
+} dc_motor_t;
 
 /*******************************************************************************
 *                               Variables
@@ -39,6 +52,14 @@
  * Effects:  Returns robot_status_t indicating state of initialization
  * Modifies: None
  * ****************************************************************************/
-robot_status_t dcMotor_init();
+robot_status_t dcMotor_init(dc_motor_t motor);
+
+/*******************************************************************************
+ * Requires: Requires dc_motor_dir_t for direciton of spin and uint8_t for
+ *           desired speed (0-256)
+ * Effects:  Returns robot_status_t indicating state of initialization
+ * Modifies: None
+ * ****************************************************************************/
+robot_status_t dcMotor_run(dc_motor_t motor, uint8_t speed, dc_motor_dir_t dir);
 
 #endif // DC_MOTOR

--- a/src/robot-tasks/task-driving.cpp
+++ b/src/robot-tasks/task-driving.cpp
@@ -59,7 +59,7 @@ static robot_task_t taskDriving =
 
 robot_status_t taskDriving_init()
 {
-    if (dcMotor_init() != ROBOT_OK)
+    if (dcMotor_init(DC_MOTOR_1) != ROBOT_OK)
     {
         return ROBOT_ERR;
     }

--- a/src/robot-tasks/task-driving.cpp
+++ b/src/robot-tasks/task-driving.cpp
@@ -63,6 +63,10 @@ robot_status_t taskDriving_init()
     {
         return ROBOT_ERR;
     }
+    if(dcMotor_init(DC_MOTOR_2) != ROBOT_OK)
+    {
+        return ROBOT_ERR;
+    }
     // Initialize the driving task pt thread
     PT_INIT(&taskDriving.taskThread);
     // Initialize the driving task pt sem


### PR DESCRIPTION
**Overview**

This PR addresses issues #1 and #2, which involve creating a module to control a DC motor and a module to call the DC motor control functions through the CLI.

**Changes**

- Added module `robot-core/dc-motor` with functions for initialising motors and running them at a specific speed / direction
- Added module `robot-cli/cli-dc-motor` with support for manually calling `dc-motor` module functions
- Added support for two DC motors, using pins `PB8`  / `PB9`, and `PB6` / `PB7` respectively
- Added support for speed control by selecting PWM compatible motor controlling pins
- Added support for controlling voltage supplied to the H-Bridges on boot with pins `A15` and `A12`

**Notes**

It is expected that additional functions will be added to both modules as the PID controller requirements become clearer. Although Arduino Uno support has been added, it is untested and may require tweaking.