### PR TITLE
Create Unidirectional and Bidirectional DC Motor Core & CLI Modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "C_Cpp.errorSquiggles": "Disabled"
+    "C_Cpp.errorSquiggles": "Disabled",
+    "C_Cpp.dimInactiveRegions": false
 }

--- a/src/robot-cli/cli-dc-motor-one.cpp
+++ b/src/robot-cli/cli-dc-motor-one.cpp
@@ -1,0 +1,104 @@
+
+/*******************************************************************************
+*                               Standard Includes
+*******************************************************************************/
+
+/*******************************************************************************
+*                               Header File Includes
+*******************************************************************************/
+
+#include "cli-dc-motor-one.h"
+#include "robot-core/dc-motor-one.h"
+#include "robot-core/command.h"
+#include "utilities/util-vars.h"
+
+/*******************************************************************************
+*                               Static Functions
+*******************************************************************************/
+
+static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
+                              dc_motor_dir_t dir);
+
+/*******************************************************************************
+*                               Constants
+*******************************************************************************/
+
+/*******************************************************************************
+*                               Structures
+*******************************************************************************/
+
+/*******************************************************************************
+*                               Variables
+*******************************************************************************/
+
+/*******************************************************************************
+*                               Functions
+*******************************************************************************/
+
+cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
+{
+
+    motor_id_t motor_id = (motor_id_t) strtol((const char*) args[0], NULL, 0);
+
+    if (motor_id != MOTOR_3)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " motor\"}" CMD_EOL_STR));
+    }
+    else if (dcMotorOne_init(&roller_motor) != ROBOT_OK)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor init"
+                     " failed\"}" CMD_EOL_STR));        
+    }
+    else
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
+    }
+    return COMMAND_OK;
+}
+
+cli_status_t cliDcMotor_run(uint8_t argNumber, char* args[])
+{
+    motor_id_t motor_id = (motor_id_t) strtol((const char*) args[0], 
+                                           NULL, 0);
+    uint8_t speed = (uint8_t) strtol((const char*) args[1], 
+                                     NULL, 0);
+    if (motor != MOTOR_3)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " motor\"}" CMD_EOL_STR));
+        return COMMAND_OK;
+    }
+    if (speed < STATIC_SPEED || speed > MAX_SPEED)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": invalid"
+                     " speed\"}" CMD_EOL_STR));
+        return COMMAND_OK;
+    }
+
+    if (strcmp(args[2], "left") == 0)
+    {
+        _runMotorFeedback(motor, speed, CC_DIRECTION);
+    }
+    else if (strcmp(args[2], "right") == 0)
+    {
+        _runMotorFeedback(motor, speed, CW_DIRECTION);
+    }
+    else
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " direction\"}" CMD_EOL_STR));
+    }
+    return COMMAND_OK;
+}
+
+static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
+                                        dc_motor_dir_t dir)
+{
+    if (dcMotor_run(motor, speed, dir) != ROBOT_OK)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor run"
+                     " failed\"}" CMD_EOL_STR));
+    }
+    Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
+}

--- a/src/robot-cli/cli-dc-motor-one.cpp
+++ b/src/robot-cli/cli-dc-motor-one.cpp
@@ -16,8 +16,8 @@
 *                               Static Functions
 *******************************************************************************/
 
-static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
-                              dc_motor_dir_t dir);
+// static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
+//                               dc_motor_dir_t dir);
 
 /*******************************************************************************
 *                               Constants
@@ -37,7 +37,7 @@ static void _runMotorFeedback(dc_motor_t motor, uint8_t speed,
 
 cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
 {
-
+    // parse motor id from cli entry
     motor_id_t motor_id = (motor_id_t) strtol((const char*) args[0], NULL, 0);
 
     if (motor_id != MOTOR_3)
@@ -45,7 +45,12 @@ cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
                      " motor\"}" CMD_EOL_STR));
     }
-    else if (dcMotorOne_init(&roller_motor) != ROBOT_OK)
+    // get pointer to dc motor type corresponding to id
+    dc_motor_one_t* motor = dcMotorOne_get(motor_id);
+    // initilize the motor
+
+    // elicite response message in json format to the serial terminal
+    if (dcMotorOne_init(motor) != ROBOT_OK)
     {
         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor init"
                      " failed\"}" CMD_EOL_STR));        
@@ -57,48 +62,48 @@ cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
     return COMMAND_OK;
 }
 
-cli_status_t cliDcMotor_run(uint8_t argNumber, char* args[])
-{
-    motor_id_t motor_id = (motor_id_t) strtol((const char*) args[0], 
-                                           NULL, 0);
-    uint8_t speed = (uint8_t) strtol((const char*) args[1], 
-                                     NULL, 0);
-    if (motor != MOTOR_3)
-    {
-        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
-                     " motor\"}" CMD_EOL_STR));
-        return COMMAND_OK;
-    }
-    if (speed < STATIC_SPEED || speed > MAX_SPEED)
-    {
-        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": invalid"
-                     " speed\"}" CMD_EOL_STR));
-        return COMMAND_OK;
-    }
+// cli_status_t cliDcMotor_run(uint8_t argNumber, char* args[])
+// {
+//     motor_id_t motor_id = (motor_id_t) strtol((const char*) args[0], 
+//                                            NULL, 0);
+//     uint8_t speed = (uint8_t) strtol((const char*) args[1], 
+//                                      NULL, 0);
+//     if (motor != MOTOR_3)
+//     {
+//         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+//                      " motor\"}" CMD_EOL_STR));
+//         return COMMAND_OK;
+//     }
+//     if (speed < STATIC_SPEED || speed > MAX_SPEED)
+//     {
+//         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": invalid"
+//                      " speed\"}" CMD_EOL_STR));
+//         return COMMAND_OK;
+//     }
 
-    if (strcmp(args[2], "left") == 0)
-    {
-        _runMotorFeedback(motor, speed, CC_DIRECTION);
-    }
-    else if (strcmp(args[2], "right") == 0)
-    {
-        _runMotorFeedback(motor, speed, CW_DIRECTION);
-    }
-    else
-    {
-        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
-                     " direction\"}" CMD_EOL_STR));
-    }
-    return COMMAND_OK;
-}
+//     if (strcmp(args[2], "left") == 0)
+//     {
+//         _runMotorFeedback(motor, speed, CC_DIRECTION);
+//     }
+//     else if (strcmp(args[2], "right") == 0)
+//     {
+//         _runMotorFeedback(motor, speed, CW_DIRECTION);
+//     }
+//     else
+//     {
+//         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+//                      " direction\"}" CMD_EOL_STR));
+//     }
+//     return COMMAND_OK;
+// }
 
-static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
-                                        dc_motor_dir_t dir)
-{
-    if (dcMotor_run(motor, speed, dir) != ROBOT_OK)
-    {
-        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor run"
-                     " failed\"}" CMD_EOL_STR));
-    }
-    Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
-}
+// static void _runMotorFeedback(dc_motor_t motor, uint8_t speed, 
+//                                         dc_motor_dir_t dir)
+// {
+//     if (dcMotor_run(motor, speed, dir) != ROBOT_OK)
+//     {
+//         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor run"
+//                      " failed\"}" CMD_EOL_STR));
+//     }
+//     Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
+// }

--- a/src/robot-cli/cli-dc-motor-one.cpp
+++ b/src/robot-cli/cli-dc-motor-one.cpp
@@ -35,7 +35,7 @@
 *                               Functions
 *******************************************************************************/
 
-cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
+cli_status_t cliDcMotorOne_init(uint8_t argNumber, char* args[])
 {
     // parse motor id from cli entry
     motor_id_t motor_id = (motor_id_t) strtol((const char*) args[0], NULL, 0);
@@ -44,6 +44,7 @@ cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
     {
         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
                      " motor\"}" CMD_EOL_STR));
+        return COMMAND_OK;
     }
     // get pointer to dc motor type corresponding to id
     dc_motor_one_t* motor = dcMotorOne_get(motor_id);
@@ -58,6 +59,34 @@ cli_status_t cliDcMotor_init(uint8_t argNumber, char* args[])
     else
     {
         Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
+    }
+    return COMMAND_OK;
+}
+
+cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[])
+{
+    motor_id_t motor_id = (motor_id_t) strtol((const char*) args[0], NULL, 0);
+    uint8_t speed = (uint8_t) strtol((const char*) args[1], NULL, 0);
+
+    if (motor_id != MOTOR_3)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " motor\"}" CMD_EOL_STR));
+        return COMMAND_OK;
+    }
+    if (speed > MAX_SPEED || speed < STATIC_SPEED)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": invalid"
+                     " speed\"}" CMD_EOL_STR));
+        return COMMAND_OK;
+    }
+
+    dc_motor_one_t* motor = dcMotorOne_get(motor_id);
+
+    if (dcMotorOne_run(motor, speed))
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
+                     " motor\"}" CMD_EOL_STR));
     }
     return COMMAND_OK;
 }

--- a/src/robot-cli/cli-dc-motor-one.h
+++ b/src/robot-cli/cli-dc-motor-one.h
@@ -1,7 +1,6 @@
 
-#ifndef COMMAND_LISTING
-#define COMMAND_LISTING
-
+#ifndef CLI_DC_MOTOR_ONE
+#define CLI_DC_MOTOR_ONE
 /*******************************************************************************
 *                               Standard Includes
 *******************************************************************************/
@@ -10,11 +9,7 @@
 *                               Header File Includes
 *******************************************************************************/
 
-#include "robot-core/command.h"
 #include "cli-command.h"
-#include "cli-dc-motor.h"
-#include "cli-dc-motor-one.h"
-#include "cli-sonar.h"
 
 /*******************************************************************************
 *                               Static Functions
@@ -24,26 +19,23 @@
 *                               Constants
 *******************************************************************************/
 
-#define LIST_TERMINATOR "END_OF_LIST"
-
 /*******************************************************************************
 *                               Structures
 *******************************************************************************/
 
 /*******************************************************************************
-*                               Variables 
+*                               Variables
 *******************************************************************************/
-
-static const command_t commandArr[] = {
-    COMMAND_COMMANDS
-    DC_MOTOR_COMMANDS
-    DC_MOTOR_ONE_COMMANDS
-    SONAR_COMMANDS
-    {NULL, LIST_TERMINATOR, NULL, NULL, 0, 0}
-};
 
 /*******************************************************************************
 *                               Functions
 *******************************************************************************/
 
-#endif // COMMAND_LISTING
+cli_status_t cliDcMotorOne_init(uint8_t argNumber, char* args[]);
+
+cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[]);
+
+#define DC_MOTOR_ONE_COMMANDS                                                                     \
+    {cliDcMotorOne_init, "dc-one-init", "<periph>",               "init the 1D dc-motor periph", 1, 1}, \
+    {cliDcMotorOne_run,  "dc-one-run",  "<periph> <speed> <dir>", "run the 1D dc motor",         3, 3},
+#endif // CLI_DC_MOTOR_ONE

--- a/src/robot-cli/cli-dc-motor-one.h
+++ b/src/robot-cli/cli-dc-motor-one.h
@@ -35,9 +35,9 @@
 
 cli_status_t cliDcMotorOne_init(uint8_t argNumber, char* args[]);
 
-// cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[]);
+cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[]);
 
 #define DC_MOTOR_ONE_COMMANDS                                                                     \
-    {cliDcMotorOne_init, "dc-one-init", "<periph>",               "init the 1D dc-motor periph", 1, 1},\
-    // {cliDcMotorOne_run,  "dc-one-run",  "<periph> <speed> <dir>", "run the 1D dc motor",         3, 3},
+    {cliDcMotorOne_init, "dc-one-init", "<periph>",         "init the 1D dc-motor periph", 1, 1},\
+    {cliDcMotorOne_run,  "dc-one-run",  "<periph> <speed>", "run the 1D dc motor",         2, 2},
 #endif // CLI_DC_MOTOR_ONE

--- a/src/robot-cli/cli-dc-motor-one.h
+++ b/src/robot-cli/cli-dc-motor-one.h
@@ -10,6 +10,8 @@
 *******************************************************************************/
 
 #include "cli-command.h"
+#include "utilities/util-vars.h"
+#include "cli-dc-motor-one.h"
 
 /*******************************************************************************
 *                               Static Functions
@@ -33,9 +35,9 @@
 
 cli_status_t cliDcMotorOne_init(uint8_t argNumber, char* args[]);
 
-cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[]);
+// cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[]);
 
 #define DC_MOTOR_ONE_COMMANDS                                                                     \
-    {cliDcMotorOne_init, "dc-one-init", "<periph>",               "init the 1D dc-motor periph", 1, 1}, \
-    {cliDcMotorOne_run,  "dc-one-run",  "<periph> <speed> <dir>", "run the 1D dc motor",         3, 3},
+    {cliDcMotorOne_init, "dc-one-init", "<periph>",               "init the 1D dc-motor periph", 1, 1},\
+    // {cliDcMotorOne_run,  "dc-one-run",  "<periph> <speed> <dir>", "run the 1D dc motor",         3, 3},
 #endif // CLI_DC_MOTOR_ONE

--- a/src/robot-cli/cli-dc-motor-two.cpp
+++ b/src/robot-cli/cli-dc-motor-two.cpp
@@ -7,8 +7,8 @@
 *                               Header File Includes
 *******************************************************************************/
 
-#include "cli-dc-motor-one.h"
-#include "robot-core/dc-motor-one.h"
+#include "cli-dc-motor-two.h"
+#include "robot-core/dc-motor-two.h"
 #include "robot-core/command.h"
 #include "utilities/util-vars.h"
 
@@ -32,18 +32,26 @@
 *                               Functions
 *******************************************************************************/
 
-cli_status_t cliDcMotorOne_init(uint8_t argNumber, char* args[])
+cli_status_t cliDcMotorTwo_init(uint8_t argNumber, char* args[])
 {
-    dc_motor_one_id_t motor_id = (dc_motor_one_id_t) strtol((const char*)
+    dc_motor_two_id_t motor_id = (dc_motor_two_id_t) strtol((const char*)
                                                             args[0], NULL, 0);
-    if (motor_id != ROLLER_MOTOR)
+    dc_motor_two_t* motor;
+    if (motor_id == LEFT_DRIVING_MOTOR)
+    {
+        motor = dcMotorTwo_get(LEFT_DRIVING_MOTOR);
+    }
+    else if (motor_id == RIGHT_DRIVING_MOTOR)
+    {
+        motor = dcMotorTwo_get(RIGHT_DRIVING_MOTOR);
+    }
+    else
     {
         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
                      " motor\"}" CMD_EOL_STR));
         return COMMAND_OK;
     }
-    dc_motor_one_t* motor = dcMotorOne_get(motor_id);
-    if (dcMotorOne_init(motor) == ROBOT_OK)
+    if (dcMotorTwo_init(motor) == ROBOT_OK)
     {
         Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));   
     }
@@ -55,12 +63,22 @@ cli_status_t cliDcMotorOne_init(uint8_t argNumber, char* args[])
     return COMMAND_OK;
 }
 
-cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[])
+cli_status_t cliDcMotorTwo_run(uint8_t argNumber, char* args[])
 {
-    dc_motor_one_id_t motor_id = (dc_motor_one_id_t) strtol((const char*)
+    dc_motor_two_id_t motor_id = (dc_motor_two_id_t) strtol((const char*)
                                                             args[0], NULL, 0);
     uint8_t speed = (uint8_t) strtol((const char*) args[1], NULL, 0);
-    if (motor_id != ROLLER_MOTOR)
+
+    dc_motor_two_t* motor;
+    if (motor_id == LEFT_DRIVING_MOTOR)
+    {
+        motor = dcMotorTwo_get(LEFT_DRIVING_MOTOR);
+    }
+    else if (motor_id == RIGHT_DRIVING_MOTOR)
+    {
+        motor = dcMotorTwo_get(RIGHT_DRIVING_MOTOR);
+    }
+    else
     {
         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
                      " motor\"}" CMD_EOL_STR));
@@ -72,11 +90,32 @@ cli_status_t cliDcMotorOne_run(uint8_t argNumber, char* args[])
                      " speed\"}" CMD_EOL_STR));
         return COMMAND_OK;
     }
-    dc_motor_one_t* motor = dcMotorOne_get(motor_id);
-    if (dcMotorOne_run(motor, speed))
+
+    rotation_dir_t direction;
+    if (strcmp(args[2], "cw") == 0)
+    {
+        direction = CW_DIRECTION;
+    }
+    else if (strcmp(args[2], "ccw") == 0)
+    {
+        direction = CCW_DIRECTION;
+    }
+    else
     {
         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"invalid"
-                     " motor\"}" CMD_EOL_STR));
+                     " direction\"}" CMD_EOL_STR));
+        return COMMAND_OK;
     }
+
+    if (dcMotorTwo_run(motor, speed, direction) == ROBOT_OK)
+    {
+        Serial.print(F(CMD_JSON "{\"status\": \"success\"}" CMD_EOL_STR));
+    }
+    else
+    {
+         Serial.print(F(CMD_JSON "{\"status\": \"error\", \"data\": \"motor run"
+                     " failed\"}" CMD_EOL_STR));
+    }
+
     return COMMAND_OK;
 }

--- a/src/robot-cli/cli-dc-motor-two.h
+++ b/src/robot-cli/cli-dc-motor-two.h
@@ -1,15 +1,17 @@
 
+#ifndef CLI_DC_MOTOR_TWO
+#define CLI_DC_MOTOR_TWO
 /*******************************************************************************
-*                               Standard Libraries
+*                               Standard Includes
 *******************************************************************************/
 
-#include <Arduino.h>
-
 /*******************************************************************************
-*                               Header Files
+*                               Header File Includes
 *******************************************************************************/
 
-#include "dc-motor-one.h"
+#include "cli-command.h"
+#include "utilities/util-vars.h"
+#include "cli-dc-motor-two.h"
 
 /*******************************************************************************
 *                               Static Functions
@@ -27,45 +29,15 @@
 *                               Variables
 *******************************************************************************/
 
-static dc_motor_one_t dcMotorOneArr[] =
-{
-    [ROLLER_MOTOR] = 
-    {
-        .pin         = PA7,
-        .speed       = STATIC_SPEED,
-        .id          = ROLLER_MOTOR,
-        .initialized = false
-    }
-};
-
 /*******************************************************************************
 *                               Functions
 *******************************************************************************/
 
-robot_status_t dcMotorOne_init(dc_motor_one_t* motor)
-{
-    pinMode(motor->pin, OUTPUT);
-    motor->speed = STATIC_SPEED;
-    analogWrite(motor->pin, motor->speed);
-    motor->initialized = true;
-    return ROBOT_OK;
-}
+cli_status_t cliDcMotorTwo_init(uint8_t argNumber, char* args[]);
 
-robot_status_t dcMotorOne_run(dc_motor_one_t* motor, uint8_t speed)
-{
-    if (motor->initialized)
-    {
-        motor->speed = speed;
-        analogWrite(motor->pin, motor->speed);
-        return ROBOT_OK;
-    }
-    else
-    {
-        return ROBOT_ERR;
-    }
-}
+cli_status_t cliDcMotorTwo_run(uint8_t argNumber, char* args[]);
 
-dc_motor_one_t* dcMotorOne_get(dc_motor_one_id_t id) 
-{
-    return &dcMotorOneArr[id];
-}
+#define DC_MOTOR_TWO_COMMANDS                                                                     \
+    {cliDcMotorTwo_init, "dc-two-init", "<periph>",         "init the 2D dc-motor periph", 1, 1}, \
+    {cliDcMotorTwo_run,  "dc-two-run",  "<periph> <speed> <dir>", "run the 2D dc motor", 3, 3},
+#endif // CLI_DC_MOTOR_TWO

--- a/src/robot-cli/command-listing.h
+++ b/src/robot-cli/command-listing.h
@@ -14,6 +14,7 @@
 #include "cli-command.h"
 #include "cli-dc-motor.h"
 #include "cli-dc-motor-one.h"
+#include "cli-dc-motor-two.h"
 #include "cli-sonar.h"
 
 /*******************************************************************************
@@ -38,6 +39,7 @@ static const command_t commandArr[] = {
     COMMAND_COMMANDS
     DC_MOTOR_COMMANDS
     DC_MOTOR_ONE_COMMANDS
+    DC_MOTOR_TWO_COMMANDS
     SONAR_COMMANDS
     {NULL, LIST_TERMINATOR, NULL, NULL, 0, 0}
 };

--- a/src/robot-core/dc-motor-one.cpp
+++ b/src/robot-core/dc-motor-one.cpp
@@ -27,7 +27,12 @@
 *                               Variables
 *******************************************************************************/
 
-struct dc_motor_one_t roller_motor = {.pin = PA7, .speed = STATIC_SPEED, .id = MOTOR_3};
+struct dc_motor_one_t roller_motor = 
+{
+    .pin = PA7, 
+    .speed = STATIC_SPEED, 
+    .id = MOTOR_3
+};
 
 
 /*******************************************************************************
@@ -47,4 +52,9 @@ robot_status_t dcMotorOne_run(dc_motor_one_t* motor, uint8_t speed)
     motor->speed = speed;
     analogWrite(motor->pin, motor->speed);
     return ROBOT_OK;
+}
+
+dc_motor_one_t* dcMotorOne_get(motor_id_t motorId) 
+{
+    return &roller_motor;
 }

--- a/src/robot-core/dc-motor-one.cpp
+++ b/src/robot-core/dc-motor-one.cpp
@@ -1,20 +1,15 @@
 
-#ifndef COMMAND_LISTING
-#define COMMAND_LISTING
-
 /*******************************************************************************
-*                               Standard Includes
+*                               Standard Libraries
 *******************************************************************************/
 
+#include <Arduino.h>
+
 /*******************************************************************************
-*                               Header File Includes
+*                               Header Files
 *******************************************************************************/
 
-#include "robot-core/command.h"
-#include "cli-command.h"
-#include "cli-dc-motor.h"
-#include "cli-dc-motor-one.h"
-#include "cli-sonar.h"
+#include "dc-motor-one.h"
 
 /*******************************************************************************
 *                               Static Functions
@@ -24,26 +19,32 @@
 *                               Constants
 *******************************************************************************/
 
-#define LIST_TERMINATOR "END_OF_LIST"
-
 /*******************************************************************************
 *                               Structures
 *******************************************************************************/
 
 /*******************************************************************************
-*                               Variables 
+*                               Variables
 *******************************************************************************/
 
-static const command_t commandArr[] = {
-    COMMAND_COMMANDS
-    DC_MOTOR_COMMANDS
-    DC_MOTOR_ONE_COMMANDS
-    SONAR_COMMANDS
-    {NULL, LIST_TERMINATOR, NULL, NULL, 0, 0}
-};
+struct dc_motor_one_t roller_motor = {.pin = PA7, .speed = STATIC_SPEED, .id = MOTOR_3};
+
 
 /*******************************************************************************
 *                               Functions
 *******************************************************************************/
 
-#endif // COMMAND_LISTING
+robot_status_t dcMotorOne_init(dc_motor_one_t* motor)
+{
+    pinMode(motor->pin, OUTPUT);
+    motor->speed = STATIC_SPEED;
+    analogWrite(motor->pin, motor->speed);
+    return ROBOT_OK;
+}
+
+robot_status_t dcMotorOne_run(dc_motor_one_t* motor, uint8_t speed)
+{
+    motor->speed = speed;
+    analogWrite(motor->pin, motor->speed);
+    return ROBOT_OK;
+}

--- a/src/robot-core/dc-motor-one.h
+++ b/src/robot-core/dc-motor-one.h
@@ -1,16 +1,19 @@
-#ifndef UTIL_VARS_H
-#define UTIL_VARS_H
+
+#ifndef DC_MOTOR_ONE
+#define DC_MOTOR_ONE
 
 /*******************************************************************************
-*                               Standard Includes
+*                               Standard Libraries
 *******************************************************************************/
 
 #include <pt.h>
-#include <pt-sem.h>
+#include <stdint.h>
 
 /*******************************************************************************
-*                               Header File Includes
+*                               Header Files
 *******************************************************************************/
+
+#include "utilities/util-vars.h"
 
 /*******************************************************************************
 *                               Static Functions
@@ -20,37 +23,19 @@
 *                               Constants
 *******************************************************************************/
 
+#define MAX_SPEED    255
+#define STATIC_SPEED 0
+
 /*******************************************************************************
 *                               Structures
 *******************************************************************************/
 
-typedef void (*ISR_func_t)(void);
-
-typedef enum {
-    ROBOT_OK,
-    ROBOT_ERR
-} robot_status_t;
-
-typedef enum {
-    ROBOT_CLI,
-    ROBOT_DRIVING,
-    ROBOT_CLAW
-} robot_task_id_t;
-
-typedef enum
+struct dc_motor_one_t
 {
-    MOTOR_1,
-    MOTOR_2,
-    MOTOR_3
-} motor_id_t;
-
-typedef struct{
-    struct pt_sem   taskMutex;
-    struct pt       taskThread;
-    robot_task_id_t taskId;
-    ISR_func_t      taskISR;
-    unsigned long   taskTime;
-} robot_task_t;
+    uint8_t pin;
+    uint8_t speed;
+    motor_id_t id;
+};
 
 /*******************************************************************************
 *                               Variables
@@ -60,4 +45,27 @@ typedef struct{
 *                               Functions
 *******************************************************************************/
 
-#endif // UTIL_VARS_H
+/*******************************************************************************
+ * Requires: pin_number corresponding to the PWM output to the unidirectional DC
+ *           motor
+ * Effects:  Returns dc_motor_1d_t pointer
+ * Modifies: None
+ * ****************************************************************************/
+robot_status_t dcMotorOne_init(dc_motor_one_t* motor);
+
+/*******************************************************************************
+ * Requires: speed ranging from 0-255 that maps linearly to to the min and max
+ *           speeds of the unidirectional DC motor
+ * Effects:  Returns robot_status_t indicating state of motor after function
+ *           call
+ * Modifies: self
+ * ****************************************************************************/
+robot_status_t dcMotorOne_run(dc_motor_one_t* motor, uint8_t speed);
+
+#endif // DC_MOTOR_ONE
+
+
+// dc_motor_one_t ROLLER_MOTOR;
+// dcMotorOne_init(ROLLER_MOTOR, ROLLER_MOTOR_PIN)
+// ...
+// dcMotorOne_run(ROLLER_MOTOR, 238)

--- a/src/robot-core/dc-motor-one.h
+++ b/src/robot-core/dc-motor-one.h
@@ -30,11 +30,17 @@
 *                               Structures
 *******************************************************************************/
 
+typedef enum
+{
+    ROLLER_MOTOR
+} dc_motor_one_id_t;
+
 struct dc_motor_one_t
 {
-    uint8_t pin;
+    const uint8_t pin;
     uint8_t speed;
-    motor_id_t id;
+    const dc_motor_one_id_t id;
+    bool initialized;
 };
 
 /*******************************************************************************
@@ -46,28 +52,30 @@ struct dc_motor_one_t
 *******************************************************************************/
 
 /*******************************************************************************
- * Requires: pin_number corresponding to the PWM output to the unidirectional DC
- *           motor
- * Effects:  Returns dc_motor_1d_t pointer
- * Modifies: None
+ * Requires: ptr to dc_motor_one_t motor that has been initialized with a pin,
+ *           and id
+ * Effects:  returns ROBOT_OK if motor has been initialized without error, and
+ *           ROBOT_ERR otherwise
+ * Modifies: motor
  * ****************************************************************************/
 robot_status_t dcMotorOne_init(dc_motor_one_t* motor);
 
 /*******************************************************************************
- * Requires: speed ranging from 0-255 that maps linearly to to the min and max
- *           speeds of the unidirectional DC motor
- * Effects:  Returns robot_status_t indicating state of motor after function
- *           call
- * Modifies: self
+ * Requires: ptr to dc_motor_one_t motor that has been initialized using
+ *           dcMotorOne_init; speed ranges from 0-255 that maps linearly to to
+ *           the min and max speeds of the unidirectional DC motor
+ * Effects:  returns ROBOT_ERR if motor was not initialized using
+ *           dcMotorOne_init, and returns ROBOT_OK otherwise
+ * Modifies: motor
  * ****************************************************************************/
 robot_status_t dcMotorOne_run(dc_motor_one_t* motor, uint8_t speed);
 
-dc_motor_one_t* dcMotorOne_get(motor_id_t motorId);
+/*******************************************************************************
+ * Requires: dc_motor_one_id_t id that corresponds to a given dc_motor_one_t
+ *           motor
+ * Effects:  returns a ptr to the corresponding dc_motor_one_t motor
+ * Modifies: None
+ * ****************************************************************************/
+dc_motor_one_t* dcMotorOne_get(dc_motor_one_id_t id);
 
 #endif // DC_MOTOR_ONE
-
-
-// dc_motor_one_t ROLLER_MOTOR;
-// dcMotorOne_init(ROLLER_MOTOR, ROLLER_MOTOR_PIN)
-// ...
-// dcMotorOne_run(ROLLER_MOTOR, 238)

--- a/src/robot-core/dc-motor-one.h
+++ b/src/robot-core/dc-motor-one.h
@@ -62,6 +62,8 @@ robot_status_t dcMotorOne_init(dc_motor_one_t* motor);
  * ****************************************************************************/
 robot_status_t dcMotorOne_run(dc_motor_one_t* motor, uint8_t speed);
 
+dc_motor_one_t* dcMotorOne_get(motor_id_t motorId);
+
 #endif // DC_MOTOR_ONE
 
 

--- a/src/robot-core/dc-motor-two.cpp
+++ b/src/robot-core/dc-motor-two.cpp
@@ -1,20 +1,15 @@
 
-#ifndef COMMAND_LISTING
-#define COMMAND_LISTING
-
 /*******************************************************************************
-*                               Standard Includes
+*                               Standard Libraries
 *******************************************************************************/
 
+#include <Arduino.h>
+
 /*******************************************************************************
-*                               Header File Includes
+*                               Header Files
 *******************************************************************************/
 
-#include "robot-core/command.h"
-#include "cli-command.h"
-#include "cli-dc-motor.h"
-#include "cli-dc-motor-one.h"
-#include "cli-sonar.h"
+#include "dc-motor-two.h"
 
 /*******************************************************************************
 *                               Static Functions
@@ -24,26 +19,50 @@
 *                               Constants
 *******************************************************************************/
 
-#define LIST_TERMINATOR "END_OF_LIST"
-
 /*******************************************************************************
 *                               Structures
 *******************************************************************************/
 
 /*******************************************************************************
-*                               Variables 
+*                               Variables
 *******************************************************************************/
-
-static const command_t commandArr[] = {
-    COMMAND_COMMANDS
-    DC_MOTOR_COMMANDS
-    DC_MOTOR_ONE_COMMANDS
-    SONAR_COMMANDS
-    {NULL, LIST_TERMINATOR, NULL, NULL, 0, 0}
-};
 
 /*******************************************************************************
 *                               Functions
 *******************************************************************************/
 
-#endif // COMMAND_LISTING
+robot_status_t dcMotorTwo_init(dc_motor_two_t* motor, uint8_t cw_pin_number,
+                              uint8_t ccw_pin_number)
+{
+    motor->cw_pin = cw_pin_number;
+    motor->ccw_pin = ccw_pin_number;
+    motor->direction = CW_DIRECTION;
+    motor->speed = STATIC_SPEED;
+
+    pinMode(motor->cw_pin, OUTPUT);
+    pinMode(motor->ccw_pin, OUTPUT);
+    analogWrite(motor->cw_pin, motor->speed);
+    analogWrite(motor->ccw_pin, motor->speed);
+
+    return ROBOT_OK;
+}
+
+robot_status_t dcMotorTwo_run(dc_motor_two_t* motor, uint8_t speed,
+                             rotation_dir_t direction)
+{
+    motor->speed = speed;
+    motor->direction = direction;
+
+    if (direction == CW_DIRECTION) 
+    {
+        analogWrite(motor->cw_pin, motor->speed);
+        analogWrite(motor->ccw_pin, STATIC_SPEED);
+    }
+    else
+    {
+        analogWrite(motor->cw_pin, STATIC_SPEED);
+        analogWrite(motor->ccw_pin, motor->speed);
+    }
+
+    return ROBOT_OK;
+}

--- a/src/robot-core/dc-motor-two.cpp
+++ b/src/robot-core/dc-motor-two.cpp
@@ -27,42 +27,69 @@
 *                               Variables
 *******************************************************************************/
 
+static dc_motor_two_t dcMotorTwoArr[] =
+{
+    [LEFT_DRIVING_MOTOR] =
+    {
+        .cw_pin      = PB6,
+        .ccw_pin     = PB7,
+        .direction   = CW_DIRECTION,
+        .speed       = STATIC_SPEED,
+        .id          = LEFT_DRIVING_MOTOR,
+        .initialized = false
+    },
+    [RIGHT_DRIVING_MOTOR] =
+    {
+        .cw_pin      = PB9,
+        .ccw_pin     = PB8,
+        .direction   = CW_DIRECTION,
+        .speed       = STATIC_SPEED,
+        .id          = RIGHT_DRIVING_MOTOR,
+        .initialized = false
+    }
+};
+
 /*******************************************************************************
 *                               Functions
 *******************************************************************************/
 
-robot_status_t dcMotorTwo_init(dc_motor_two_t* motor, uint8_t cw_pin_number,
-                              uint8_t ccw_pin_number)
+robot_status_t dcMotorTwo_init(dc_motor_two_t* motor)
 {
-    motor->cw_pin = cw_pin_number;
-    motor->ccw_pin = ccw_pin_number;
-    motor->direction = CW_DIRECTION;
-    motor->speed = STATIC_SPEED;
-
     pinMode(motor->cw_pin, OUTPUT);
     pinMode(motor->ccw_pin, OUTPUT);
+    motor->speed = STATIC_SPEED;
     analogWrite(motor->cw_pin, motor->speed);
     analogWrite(motor->ccw_pin, motor->speed);
-
+    motor->initialized = true;
     return ROBOT_OK;
 }
 
 robot_status_t dcMotorTwo_run(dc_motor_two_t* motor, uint8_t speed,
-                             rotation_dir_t direction)
+                              rotation_dir_t direction)
 {
-    motor->speed = speed;
-    motor->direction = direction;
-
-    if (direction == CW_DIRECTION) 
+    if (motor->initialized)
     {
-        analogWrite(motor->cw_pin, motor->speed);
-        analogWrite(motor->ccw_pin, STATIC_SPEED);
+        motor->speed = speed;
+        motor->direction = direction;
+        if (direction == CW_DIRECTION) 
+        {
+            analogWrite(motor->cw_pin, motor->speed);
+            analogWrite(motor->ccw_pin, STATIC_SPEED);
+        }
+        else
+        {
+            analogWrite(motor->cw_pin, STATIC_SPEED);
+            analogWrite(motor->ccw_pin, motor->speed);
+        }
+        return ROBOT_OK;
     }
     else
     {
-        analogWrite(motor->cw_pin, STATIC_SPEED);
-        analogWrite(motor->ccw_pin, motor->speed);
+        return ROBOT_ERR;
     }
+}
 
-    return ROBOT_OK;
+dc_motor_two_t* dcMotorTwo_get(dc_motor_two_id_t id)
+{
+    return &dcMotorTwoArr[id];
 }

--- a/src/robot-core/dc-motor-two.h
+++ b/src/robot-core/dc-motor-two.h
@@ -1,0 +1,73 @@
+
+#ifndef DC_MOTOR_TWO
+#define DC_MOTOR_TWO
+
+/*******************************************************************************
+*                               Standard Libraries
+*******************************************************************************/
+
+#include <pt.h>
+#include <stdint.h>
+
+/*******************************************************************************
+*                               Header Files
+*******************************************************************************/
+
+#include "utilities/util-vars.h"
+
+/*******************************************************************************
+*                               Static Functions
+*******************************************************************************/
+
+/*******************************************************************************
+*                               Constants
+*******************************************************************************/
+
+#define MAX_SPEED    255
+#define STATIC_SPEED 0
+
+/*******************************************************************************
+*                               Structures
+*******************************************************************************/
+
+typedef enum {
+    CW_DIRECTION,
+    CCW_DIRECTION
+} rotation_dir_t;
+
+struct dc_motor_two_t
+{
+    uint8_t cw_pin;
+    uint8_t ccw_pin;
+    rotation_dir_t direction;
+    uint8_t speed;
+};
+
+/*******************************************************************************
+*                               Variables
+*******************************************************************************/
+
+/*******************************************************************************
+*                               Functions
+*******************************************************************************/
+
+/*******************************************************************************
+ * Requires: pin_number corresponding to the PWM output to the unidirectional DC
+ *           motor
+ * Effects:  Returns dc_motor_1d_t pointer
+ * Modifies: None
+ * ****************************************************************************/
+robot_status_t dcMotorTwo_init(dc_motor_two_t* motor, uint8_t cw_pin_number,
+                              uint8_t ccw_pin_number);
+
+/*******************************************************************************
+ * Requires: speed ranging from 0-255 that maps linearly to to the min and max
+ *           speeds of the unidirectional DC motor
+ * Effects:  Returns robot_status_t indicating state of motor after function
+ *           call
+ * Modifies: self
+ * ****************************************************************************/
+robot_status_t dcMotorTwo_run(dc_motor_two_t* motor, uint8_t speed,
+                             rotation_dir_t direction);
+
+#endif // DC_MOTOR_TWO

--- a/src/robot-core/dc-motor-two.h
+++ b/src/robot-core/dc-motor-two.h
@@ -30,17 +30,26 @@
 *                               Structures
 *******************************************************************************/
 
-typedef enum {
+typedef enum
+{
     CW_DIRECTION,
     CCW_DIRECTION
 } rotation_dir_t;
 
+typedef enum
+{
+    LEFT_DRIVING_MOTOR,
+    RIGHT_DRIVING_MOTOR
+} dc_motor_two_id_t;
+
 struct dc_motor_two_t
 {
-    uint8_t cw_pin;
-    uint8_t ccw_pin;
+    const uint8_t cw_pin;
+    const uint8_t ccw_pin;
     rotation_dir_t direction;
     uint8_t speed;
+    const dc_motor_two_id_t id;
+    bool initialized;
 };
 
 /*******************************************************************************
@@ -52,22 +61,32 @@ struct dc_motor_two_t
 *******************************************************************************/
 
 /*******************************************************************************
- * Requires: pin_number corresponding to the PWM output to the unidirectional DC
- *           motor
- * Effects:  Returns dc_motor_1d_t pointer
- * Modifies: None
+ * Requires: ptr to dc_motor_two_t motor that has been initialized with a
+ *           cw_pin, ccw_pin, direction, speed and id
+ * Effects:  returns ROBOT_OK if motor has been initialized without error, and
+ *           ROBOT_ERR otherwise
+ * Modifies: motor
  * ****************************************************************************/
-robot_status_t dcMotorTwo_init(dc_motor_two_t* motor, uint8_t cw_pin_number,
-                              uint8_t ccw_pin_number);
+robot_status_t dcMotorTwo_init(dc_motor_two_t* motor);
 
 /*******************************************************************************
- * Requires: speed ranging from 0-255 that maps linearly to to the min and max
- *           speeds of the unidirectional DC motor
- * Effects:  Returns robot_status_t indicating state of motor after function
- *           call
- * Modifies: self
+ * Requires: ptr to dc_motor_two_t motor that has been initialized using
+ *           dcMotorTwo_init; speed ranges from 0-255 that maps linearly to to
+ *           the min and max speeds of the biidirectional DC motor; direction
+ *           is either CW_DIRECTION or CCW_DIRECTION
+ * Effects:  returns ROBOT_ERR if motor was not initialized using
+ *           dcMotorTwo_init, and returns ROBOT_OK otherwise
+ * Modifies: motor
  * ****************************************************************************/
 robot_status_t dcMotorTwo_run(dc_motor_two_t* motor, uint8_t speed,
                              rotation_dir_t direction);
+
+/*******************************************************************************
+ * Requires: dc_motor_two_id_t id that corresponds to a given dc_motor_two_t
+ *           motor
+ * Effects:  returns a ptr to the corresponding dc_motor_two_t motor
+ * Modifies: None
+ * ****************************************************************************/
+dc_motor_two_t* dcMotorTwo_get(dc_motor_two_id_t id);
 
 #endif // DC_MOTOR_TWO

--- a/src/utilities/util-vars.h
+++ b/src/utilities/util-vars.h
@@ -37,13 +37,6 @@ typedef enum {
     ROBOT_CLAW
 } robot_task_id_t;
 
-typedef enum
-{
-    MOTOR_1,
-    MOTOR_2,
-    MOTOR_3
-} motor_id_t;
-
 typedef struct{
     struct pt_sem   taskMutex;
     struct pt       taskThread;


### PR DESCRIPTION
**Overview**

This PR addresses issue #14, which entails the creation of two core modules dc-motor-one and dc-motor-two, and their corresponding CLI counterparts cli-dc-motor-one and cli-dc-motor-two. The creation of these modules allows for the control of both unidirectionally (one) and bidirectionally (two) configured DC motors. 

**Changes**
- Added module `robot-core/dc-motor-one`, which declares 1 unidirectional motor (roller) and has functions for initialization, running unidirectional motors at different speeds, and returning pointers to motor structs declared within via a unique ID
- Addded module `robot-core/dc-motor-two`, which declares 2 bidirectional motors (left & right driving) and has functions for initialization, running bidirectional motors at different speeds and in different directions, and returning pointers to motor structs declared within via a unique ID
- Added module `robot-cli/cli-dc-motor-one`, which allows for unidirectional motors to be run manually via CLI
- Added module `robot-cli/cli-dc-motor-two`, which allows for bidirectional motors to be run manually via CLI 

**Notes**
Pin PA7 was assigned in `dc-motor-one.cpp`, and pins PB6, PB7, PB8, and PB9 were assigned in `dc-motor-two.cpp`.